### PR TITLE
Improve README structure and add vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,131 @@
 # iGoUltra Backend
 
-Das iGoUltra-Backend ist die serverseitige Grundlage des iGoUltra-Ökosystems. Es bietet APIs für Authentifizierung, XP-Management, Leaderboards und weitere Spielfunktionen. Dieses Backend basiert auf **Django**, **Django REST Framework**, und verwendet **PostgreSQL** als Datenbank.
+Das iGoUltra-Backend bildet die serverseitige Grundlage des gesamten iGoUltra-Ökosystems. Es stellt REST-APIs bereit, die von Web‑Frontend, mobilen Apps, AR/VR‑Anwendungen und dem Discord‑Bot genutzt werden.
 
-## 📌 Inhaltsverzeichnis
-- [Projektbeschreibung](#projektbeschreibung)
-- [Technologien](#technologien)
-- [Setup & Installation](#setup--installation)
+## 🚀 Vision
+Das Projekt verfolgt das Ziel, Bewegung spielerisch zu fördern und virtuelle sowie reale Fitness miteinander zu verbinden. Ein zentrales Backend ermöglicht plattformübergreifende Ranglisten, Seasons und zukünftig auch eine eigene Währung.
+
+## 📖 Inhaltsverzeichnis
+- [Features](#features)
+- [Technologie-Stack](#technologie-stack)
+- [Quickstart](#quickstart)
 - [Projektstruktur](#projektstruktur)
-- [Datenbankmodelle](#datenbankmodelle)
-- [API Endpunkte](#api-endpunkte)
+- [Datenmodelle](#datenmodelle)
+- [API-Übersicht](#api-%C3%BCbersicht)
 - [Testing](#testing)
 - [Deployment](#deployment)
 - [Coding Standards](#coding-standards)
 - [Contributing](#contributing)
-- [Weiterführende Ressourcen](#weiterführende-ressourcen)
+- [Ressourcen](#ressourcen)
+- [Hinweis](#hinweis)
 
-## 📝 Projektbeschreibung
-Das Backend dient als API-first Architektur für:
-- Benutzerregistrierung und Authentifizierung (Discord OAuth / JWT)
-- XP-System (Schritte, Push-Ups, Läufe etc.)
-- Leaderboards mit Ligen und Rangsystem
-- Verwaltung von Seasons (Saisons im Spiel)
-- Unterstützung künftiger Features wie Gold-/Ultrapunkte-Währung
-- Zentrale Schnittstelle für Frontend, Mobile, AR/VR, Discord-Bot
+## ✨ Features
+- Discord OAuth und JWT‑Authentifizierung
+- XP- und Levelsystem inklusive saisonbasierter Rankings
+- Layer-abhängige Leaderboards (Real/Cyber)
+- Erweiterbare Architektur für künftige Module wie Bitgold, Wallet oder Skills
 
-## ⚙️ Technologien
-Im Folgenden werden die Kernbibliotheken und -tools aufgeführt, die im Projekt verwendet werden, sowie die Gründe für ihre Auswahl:
+## 🛠 Technologie-Stack
+Die wichtigsten Komponenten:
+- **Python 3.13** und **Django 5.2** mit **Django REST Framework**
+- **PostgreSQL** als Datenbank über `psycopg2-binary`
+- `dj-rest-auth`, `django-allauth` und `djangorestframework_simplejwt` für Authentifizierung
+- CORS-, Debug- und Extension-Tools wie `django-cors-headers`, `django-debug-toolbar` und `django-extensions`
+- Deployment-Helfer `gunicorn`, `whitenoise` sowie `dj-database-url`
 
-- **Python 3.13.x**: Moderne, leistungsfähige und weit verbreitete Programmiersprache mit umfangreichem Ökosystem. Version 3.13 bringt Performance-Verbesserungen und neue Sprachfeatures.
-- **Django 5.2**: Robustes, batteries-included Web-Framework. Bietet eingebaute Authentifizierung, Admin-Interface und klare Projektstruktur für schnelle Entwicklung und Skalierbarkeit.
-- **Django REST Framework (DRF) 3.16.0**: Erweiterung zur einfachen Erstellung von RESTful APIs. Bietet Serializers, ViewSets, Pagination und integrierte Validierung.
-- **djangorestframework_simplejwt 5.5.0**: JWT-basierte Authentifizierung für APIs. Ermöglicht sichere Token-Mechanismen, wichtig für Mobile- und externe Clients.
-- **django-allauth 65.7.0**: Social Authentication (z.B. Discord OAuth). Erleichtert Registrieren und Anbinden externer OAuth-Provider.
-- **dj-rest-auth 7.0.1**: REST-API-basierte Authendpoints unter Nutzung von django-allauth und SimpleJWT. Spart Zeit bei Login, Logout, Passwort-Reset etc.
-- **dj-database-url 2.3.0**: Datenbank-Konfiguration aus Umgebungsvariablen (DATABASE_URL). Erleichtert Deployment auf Plattformen wie Heroku, da URL-basiert.
-- **python-dotenv 1.1.0**: Lädt Umgebungsvariablen aus `.env`. Unterstützt lokale Entwicklung, verhindert Hardcodierung sensibler Daten.
-- **psycopg2-binary 2.9.10**: PostgreSQL-Adapter für Python. Standard für Django-PostgreSQL-Integration.
-- **PostgreSQL**: Leistungsfähiges, zuverlässiges relationales DBMS. Unterstützt JSONB, erweiterte Abfragen, gute Skalierbarkeit.
-- **django-cors-headers 4.7.0**: Erlaubt CORS-Konfiguration für sichere API-Aufrufe von Frontend-Clients (Web, Mobile).
-- **django-debug-toolbar 4.3.0**: Werkzeug für Analyse und Debugging in Entwicklung, um Performance-Engpässe und SQL-Abfragen zu überwachen.
-- **django-extensions 3.2.3**: Zusätzliche Management-Befehle (Shell Plus, graph_models) für effizientere Entwicklung und Debugging.
-- **drf-spectacular 0.27.1**: Automatische OpenAPI-Schema-Generierung für DRF. Erzeugt Swagger/Redoc-Doku, erleichtert API-Verbrauch.
-- **asgiref 3.8.1**: ASGI-Reference-Implementation für asynchrone Unterstützung in Django. Bereitet auf künftige asynchrone Views/Kanäle vor.
-- **gunicorn 23.0.0**: WSGI-Server für Produktion. Bewährt, performant, einfache Integration z.B. auf Heroku.
-- **whitenoise 6.9.0**: Liefert statische Dateien in Produktion ohne externes CDN. Einfach einzurichten und performant.
-- **requests 2.32.3**: HTTP-Client für externe API-Interaktionen (z.B. Wearables-APIs). Weit verbreitet und zuverlässig.
-- **PyJWT 2.9.0**: JWT-Handling-Bibliothek, in Kombination mit SimpleJWT für Token-Operationen.
-- **jsonschema 4.23.0 & jsonschema-specifications 2024.10.1**: Validierung von JSON-Datenstrukturen, etwa bei Webhook-Validierung oder komplexen Payloads.
-- **pillow 11.2.1**: Bildverarbeitung, falls Profilbilder hochgeladen und bearbeitet werden müssen.
-- **PyYAML 6.0.2**: YAML-Verarbeitung, z.B. Konfigurationsdateien oder Data-Import/Export.
-- **certifi 2025.1.31**, **charset-normalizer 3.4.1**, **idna 3.10**, **urllib3 2.4.0**: Komponenten für sichere HTTP-Kommunikation und aktuelle TLS-Zertifikate.
-- **attrs 25.3.0**: Hilfsbibliothek für Klassen mit Validierung; wird von einigen Dependencies genutzt.
-- **inflection 0.5.1**: Stringkonvertierungen (snake_case <-> CamelCase), nützlich bei Serializing/Deserializing.
-- **packaging 24.2**: Versionsvergleiche und Packaging-Tasks.
-- **referencing 0.36.2**: Bibliothek für komplexe Referenzen in Datenstrukturen, bereit für erweiterte Features.
-- **rpds-py 0.24.0**: Persistente Datenstrukturen in Python, für effiziente unveränderliche Strukturen in künftigen Modulen.
-- **sqlparse 0.5.3**: Wird von Django zur Formatierung von SQL in Shell/Debug-Toolbar genutzt.
-- **typing_extensions 4.13.2**: Zusätzliche Typ-Hinweise für Kompatibilität mit neueren Python-Versionen.
-- **tzdata 2025.2**: Zeitzonendaten für korrekte Zeitberechnungen und Scheduling.
-- **uritemplate 4.1.1**: Unterstützung für URI-Template-Manipulation, nützlich bei URL-Generierung oder Validierung.
-- **wheel 0.45.1 & setuptools 78.1.0**: Packaging-Tools, um Releases zu bauen und zu verteilen.
-- **Heroku**: Einfaches Deployment mit automatischem Scaling, ideal für MVP und frühe Tests.
-- **GitHub Actions / CI (optional)**: Automatisierung von Tests, Linting und Deployment-Pipelines.
-- **Docker (optional)**: Containerisierung für konsistente Entwicklungs- und Produktionsumgebungen.
-
-**Begründung der Auswahl**  
-- Etablierte, gut gewartete Bibliotheken gewährleisten Wartbarkeit und Sicherheit.  
-- Django & DRF: schnelle Entwicklung, klare Architektur, eingebaute Features (Auth, Admin).  
-- JWT & OAuth: flexible Authentifizierungsmechanismen für Discord-Integration und mobile/externe Clients.  
-- Tools wie drf-spectacular und django-debug-toolbar unterstützen Dokumentation und Debugging, beschleunigen Entwicklung.  
-- Deployment-Tools (Gunicorn, Whitenoise, dj-database-url, Heroku) ermöglichen reibungslosen Produktionsbetrieb.  
-- Zusätzliche Bibliotheken (requests, pillow, PyYAML) decken häufige Anwendungsfälle (Externe APIs, Bildverarbeitung, Konfigmanagement).  
-- Python 3.13: moderne Sprachfeatures, Performance-Verbesserungen.  
-- CORS, TZ-Daten und Typing-Extensions sichern robuste API-Kommunikation und korrekte Zeit-/Typbehandlung.  
-- Persistente Datenstrukturen und Referencing-Bibliotheken ermöglichen künftige Erweiterungen ohne großen Refactoring-Aufwand.  
-
-## 🚀 Setup & Installation
-### 1️⃣ Repository klonen
-```bash
-git clone https://github.com/DEIN_GITHUB_ACCOUNT/igoultra-backend.git
-cd igoultra-backend
-```
-### 2️⃣ Virtuelle Umgebung aktivieren
-```bash
-python -m venv venv
-# Windows:
-venv\Scripts\activate
-# Mac/Linux:
-source venv/bin/activate
-```
-### 3️⃣ Abhängigkeiten installieren
-```bash
-pip install -r requirements.txt
-```
-### 4️⃣ Datenbankmigrationen
-```bash
-python manage.py migrate
-```
-### 5️⃣ Superuser erstellen
-```bash
-python manage.py createsuperuser
-```
-### 6️⃣ Server starten
-```bash
-python manage.py runserver
-```
+## ⚡ Quickstart
+1. Repository klonen
+   ```bash
+   git clone https://github.com/DEIN_GITHUB_ACCOUNT/igoultra-backend.git
+   cd igoultra-backend
+   ```
+2. Virtuelle Umgebung erstellen und aktivieren
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+3. Abhängigkeiten installieren und Migrationen durchführen
+   ```bash
+   pip install -r requirements.txt
+   python manage.py migrate
+   ```
+4. Superuser anlegen und Server starten
+   ```bash
+   python manage.py createsuperuser
+   python manage.py runserver
+   ```
 
 ## 🗂 Projektstruktur
 ```plaintext
 igoultra-backend/
- ├── igoultra/               # Django Hauptprojekt
- │   ├── settings.py         # Einstellungen
- │   ├── urls.py             # URL-Routing
- │   ├── wsgi.py             # WSGI-Einstiegspunkt
- │   └── ...
- ├── xp_system/              # XP-System App
- │   ├── models.py           # Datenmodelle
- │   ├── views.py            # API-Logik
- │   ├── serializers.py      # DRF-Serializer
- │   ├── urls.py             # Routen
- │   └── ...
- ├── manage.py
- ├── requirements.txt
- └── README.md
+ ├── api/              # Versionierte API (aktuell v1)
+ ├── users/            # Benutzer und Authentifizierung
+ ├── xp/               # XP-System (Modelle, Services)
+ ├── seasons/          # Saisonverwaltung
+ ├── rankings/         # Leaderboards nach Layer
+ ├── ultrabackend/     # Django-Haupteinstellungen
+ ├── bitgold/          # Platzhalter für künftige Währung
+ ├── wallet/           # Platzhalter für Wallet-Funktionen
+ ├── inventory/        # Platzhalter für Items
+ ├── store/            # geplanter Ingame-Store
+ ├── skills/           # noch leere App für Skills
+ ├── community_rang/   # Community-Ranglisten (geplant)
+ ├── stats/            # Statistiken (geplant)
+ └── manage.py, requirements.txt, ...
 ```
 
-## 🗃 Datenbankmodelle
-### User
-Standard Django-User + optional Discord-ID.
+### App-Übersicht mit Codebeispielen
 
-### Season
+**API (`api/v1`)**
+
+```python
+class AddXpView(generics.GenericAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = AddXpSerializer
+
+    def post(self, request, *args, **kwargs):
+        ser = self.get_serializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        result = add_xp_to_user(
+            user=request.user,
+            type_key=ser.validated_data['key'],
+            amount_units=ser.validated_data['amount_units'],
+            metadata=ser.validated_data.get('metadata')
+        )
+        stats = get_xp_stats(request.user)
+        return Response({
+            'awarded_xp': result['awarded_xp'],
+            'total_xp': stats['total_xp'],
+            'level': stats['level'],
+        })
+```
+
+**Users**
+
+```python
+class User(AbstractUser):
+    discord_id = models.CharField(max_length=64, unique=True, null=True, blank=True)
+    ultra_name = models.CharField(max_length=50, unique=True, null=True, blank=True)
+    xp = models.PositiveIntegerField(default=0)
+    level = models.PositiveIntegerField(default=1)
+```
+
+**XP-Services**
+
+```python
+@transaction.atomic
+def add_xp_to_user(user, type_key, amount_units, layer_type="Real-Life", metadata=None):
+    xp_type = XpType.objects.get(key=type_key)
+    real_xp = int(amount_units * xp_type.xp_amount)
+    XpEvent.objects.create(user=user, amount=real_xp, source=type_key, layer_type=layer_type, metadata=metadata or {})
+    user.xp = max(0, user.xp + real_xp)
+    user.level = level_from_xp(user.xp)
+    user.save(update_fields=['xp', 'level'])
+    return get_xp_stats(user)
+```
+
+**Seasons**
+
 ```python
 class Season(models.Model):
     name = models.CharField(max_length=100)
@@ -138,83 +134,71 @@ class Season(models.Model):
     is_active = models.BooleanField(default=False)
 ```
 
-### SeasonXp
+**Rankings**
+
 ```python
+def process_season_end(season_id: int):
+    season = Season.objects.get(id=season_id)
+    sxps = list(SeasonXp.objects.filter(season=season).select_related("user").order_by("-xp"))
+    for pos, sxp in enumerate(sxps):
+        p = pos / len(sxps)
+        new_real = _adjust_layer(sxp.user.real_layer, REAL_LAYERS, p)
+        LayerRankingEntry.objects.create(season=season, user=sxp.user, real_layer=new_real, xp=sxp.xp)
+```
+
+## 🗃 Datenmodelle
+Beispiel einer Season und dazugehöriger XP-Zuordnung:
+```python
+class Season(models.Model):
+    name = models.CharField(max_length=100)
+    start = models.DateField()
+    end = models.DateField()
+    is_active = models.BooleanField(default=False)
+
 class SeasonXp(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     season = models.ForeignKey(Season, on_delete=models.CASCADE)
     xp = models.IntegerField()
 ```
 
-## 🔌 API Endpunkte
-| Endpoint                     | Methode | Beschreibung                    |
-|------------------------------|---------|---------------------------------|
-| `/api/v1/auth/jwt/create/`   | POST    | Login (JWT)                     |
-| `/api/v1/auth/jwt/refresh/`  | POST    | Token erneuern                  |
-| `/api/v1/xp/submit/`         | POST    | XP einreichen                   |
-| `/api/v1/xp/leaderboard/`    | GET     | Rangliste anzeigen              |
-
-### Beispiel: XP Submit
-```http
-POST /api/v1/xp/submit/
-Content-Type: application/json
-Authorization: Bearer <TOKEN>
-
-{
-  "activity": "pushups",
-  "amount": 50
-}
-```
-Antwort:
-```json
-{
-  "message": "XP submitted successfully",
-  "total_xp": 500
-}
-```
+## 📡 API-Übersicht
+| Endpoint                       | Methode | Beschreibung          |
+|--------------------------------|---------|-----------------------|
+| `/api/v1/auth/jwt/create/`     | POST    | Login via JWT         |
+| `/api/v1/auth/jwt/refresh/`    | POST    | Token erneuern        |
+| `/api/v1/xp/submit/`           | POST    | XP einreichen         |
+| `/api/v1/xp/leaderboard/`      | GET     | Rangliste abrufen     |
 
 ## ✅ Testing
-### Lokale Tests starten
+Lokale Tests ausführen:
 ```bash
 python manage.py test
 ```
-### Beispiel-Test (xp_system/tests.py)
-```python
-def test_xp_submission(self):
-    response = self.client.post('/api/v1/xp/submit/', {
-        'activity': 'pushups',
-        'amount': 10
-    }, HTTP_AUTHORIZATION=f'Bearer {self.token}')
-    self.assertEqual(response.status_code, 200)
-```
 
 ## ☁ Deployment
-Heroku Deployment:
+Standard-Deployment auf Heroku:
 ```bash
 heroku login
 heroku create igoultra-backend
 git push heroku main
 heroku run python manage.py migrate
 ```
-Domain: https://api.igoultra.de
 
 ## ✨ Coding Standards
-- Kommentare in Englisch
-- PEP8-konform
-- API-Endpoints versioniert (`/api/v1/`)
-- Modularer Code (pro App ein Bereich)
-- DRY-Prinzip (Don't Repeat Yourself)
+- Kommentare in Englisch, Code PEP8-konform
+- API-Versionierung über `/api/v1/`
+- Modularer Aufbau pro App
 
 ## 🤝 Contributing
-1. Forke das Repo  
-2. Erstelle einen Branch `feature/DEIN_FEATURE`  
-3. Push Änderungen  
-4. Stelle einen Pull Request  
+1. Forke das Repo
+2. Erstelle einen Branch `feature/DEIN_FEATURE`
+3. Push deine Änderungen
+4. Stelle einen Pull Request
 
-## 🧭 Weiterführende Ressourcen
+## 📚 Ressourcen
 - [Django Docs](https://docs.djangoproject.com/)
 - [DRF Docs](https://www.django-rest-framework.org/)
 - [Heroku Django Guide](https://devcenter.heroku.com/categories/python-support)
 
-## 📌 Hinweis
-Dieses Backend ist Teil des iGoUltra-Universums. Für Frontend, AR/VR oder Discord-Integration siehe separate Repositories.
+## Hinweis
+Dieses Backend ist Teil des iGoUltra-Universums. Für Frontend oder Discord-Integration existieren separate Repositories.


### PR DESCRIPTION
## Summary
- restructure README for better readability
- add vision section at the top
- include full project overview with app explanations and code samples

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6866071169b4832c87533f9380bf649e